### PR TITLE
Improve conversion of "established" modifier.

### DIFF
--- a/EXOS/Perl/IOStoEXOSACL/aclconverter_0_15.pl
+++ b/EXOS/Perl/IOStoEXOSACL/aclconverter_0_15.pl
@@ -286,12 +286,21 @@ while ($line = <ACLFILE>) {
          }
       }
       if ( $conmod =~ m/^EST$/ ) {
-         $conmod = "TCP-flags RST \;";
          my $oldname = $name;
-         $name = $name."_RST";
+         $name = $oldname."_SYN_ACK";
+         $conmod = "TCP-flags SYN_ACK \;";
          printentry();
          $name = $oldname."_ACK";
          $conmod = "TCP-flags ACK \;";
+         printentry();
+         $name = $oldname."_RST";
+         $conmod = "TCP-flags RST \;";
+         printentry();
+         $name = $oldname."_FIN";
+         $conmod = "TCP-flags FIN \;";
+         printentry();
+         $name = $oldname."_FIN_ACK";
+         $conmod = "TCP-flags 0x11 \;";
          printentry();
          $name = $oldname;
       } else {

--- a/EXOS/Perl/IOStoEXOSACL/tcp_established.acl
+++ b/EXOS/Perl/IOStoEXOSACL/tcp_established.acl
@@ -1,0 +1,2 @@
+ip access-list extended TEST_ESTABLISHED
+ permit tcp any any established


### PR DESCRIPTION
Cisco IOS ACLs allow to match on "established" TCP connections using the
modifier "established". This means, that packets which have either the
ACK flag or the RST flag set. Other TCP flags are ignored for the match.

ExtremeXOS ACLs can match on the TCP flags, but they match on all flags
taken together. Thus any combination of flags that are to be allowed
need to be specified separately. To convert the "established" modifier,
at least all connection control flag combinations needed to accept,
maintain, and close a connection need to be allowed.

This commit extends the current conversion, that allows the RST and
ACK flags, each as only flag of teh TCP packet, only, by allowing the
additional flag combinations SYN+ACK, FIN, and FIN+ACK. This allows most
established TCP connections to work as intended.

This still does not allow the use of ECN or of the URG or PSH flags,
while the IOS "established" modifier ignores those flags.

A better way to allow established TCP sessions would be to disallow
session establishment, that is deny all packets with a SYN and no ACK.
This again needs to deny many combinations to thwart a Xmas Tree attack.
But that change would be more intrusive than just adding a few common
flag combinations to the existing conversion.