### PR TITLE
ISC vlan length

### DIFF
--- a/EXOS/Python/README.md
+++ b/EXOS/Python/README.md
@@ -1,3 +1,8 @@
+# Documentation
+* [Snippets of Python in EXOS](Snippets_of_Python_in_EXOS.pdf?raw=true)
+* [Python Getting Started Guide](http://www.extremenetworks.com/wp-content/uploads/2015/02/Python_Getting_Started_Guide.pdf)
+* [The EXOS Python API](http://documentation.extremenetworks.com/python/)
+
 # Python Scripts
 | Script name   | Description   |
 | ------------- |:-------------:|
@@ -21,6 +26,3 @@
 | [vlanPortInfo](vlanportinfo) 			| This script displays the VLAN assignment and tagging configuration for all ports on the switch.      |
 | [vlan_elrp_check](vlan_elrp_check)	| This script will run ELRP on all VLANS on an EXOS switch.|
 | [vlan_copy_port](vlan_copy_port)		| This EXOS script will copy/move vlans from one port to another |
-
-# Documentation
-* [Snippets_of_Python_in_EXOS.pdf](Snippets_of_Python_in_EXOS.pdf)

--- a/EXOS/Python/mlag_config_check/mlag_config_check.py
+++ b/EXOS/Python/mlag_config_check/mlag_config_check.py
@@ -7,8 +7,8 @@
 
 def main():
 	# Find which vlan is the ISC vlan
-	cli_output = exsh.clicmd('show mlag peer', True).split()
-	isc_vlan = cli_output[10]
+	cli_output = exsh.clicmd('debug vsm show peer | inc "vrId      : 2"', True).split()
+	isc_vlan = cli_output[5]
 
 	# Check the number of ports added to the ISC vlan, and get the port number of the ISC link
 	cli_output = exsh.clicmd('show vlan ' + isc_vlan, True).split()


### PR DESCRIPTION
Fixed a bug where the MLAG config check will fail if the ISC vlan name is >22 characters long. (#16)