### PR TITLE
Bumped GenericNbiClient.go to v0.6.0.

### DIFF
--- a/Netsight/nbi_clients/GenericNbiClient.go/GenericNbiClient.go
+++ b/Netsight/nbi_clients/GenericNbiClient.go/GenericNbiClient.go
@@ -24,45 +24,158 @@ SOFTWARE.
 package main
 
 import (
+	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
+	"strconv"
+	"strings"
 	"time"
 )
 
+// AppConfig stores the application configuration once parsed by flags.
+type AppConfig struct {
+	XMCHost         string
+	XMCPort         uint
+	HTTPTimeout     uint
+	InsecureHTTPS   bool
+	XMCClientID     string
+	XMCClientSecret string
+	XMCUsername     string
+	XMCPassword     string
+	XMCQuery        string
+}
+
+// OAuth2Token stores the OAuth2 Token used for authentication.
+type OAuth2Token struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+}
+
+// Definitions used within the code.
 const (
-	toolName         string = "BELL XMC NBI GenericNbiClient.go"
-	toolVersion      string = "0.3.0"
-	httpUserAgent    string = toolName + "/" + toolVersion
-	errSuccess       int    = 0  // No error
-	errUsage         int    = 1  // Usage error
-	errMissArg       int    = 2  // Missing arguments
-	errHTTPRequest   int    = 10 // Error creating the HTTPS request
-	errXMCConnect    int    = 11 // Error connecting to XMC
-	errHTTPSResponse int    = 12 // Error parsing the HTTPS response
+	toolName      string = "XMC NBI GenericNbiClient.go"
+	toolVersion   string = "0.6.0"
+	httpUserAgent string = toolName + "/" + toolVersion
+	jsonMimeType  string = "application/json"
 )
 
+// Error codes.
+const (
+	errSuccess      int = 0  // No error
+	errUsage        int = 1  // Usage error
+	errMissArg      int = 2  // Missing arguments
+	errHTTPRequest  int = 10 // Error creating the HTTPS request
+	errXMCConnect   int = 11 // Error connecting to XMC
+	errHTTPResponse int = 12 // Error parsing the HTTPS response
+	errHTTPOAuth    int = 20 // Error authenticating to XMC (OAuth)
+)
+
+// Variables used to pass data between functions.
+var (
+	Config    AppConfig
+	NBIClient http.Client
+	OAuth     OAuth2Token
+)
+
+// getEnvOrDefaultString returns the string value of the environment variable "name" or "defaultVal" if that variable does not exist.
+func getEnvOrDefaultString(name string, defaultVal string) string {
+	retVal := defaultVal
+	envVal, ok := os.LookupEnv(name)
+	if ok {
+		retVal = envVal
+	}
+	return retVal
+}
+
+// getEnvOrDefaultUint returns the uint value of the environment variable "name" or "defaultVal" if that variable does not exist.
+func getEnvOrDefaultUint(name string, defaultVal uint) uint {
+	retVal := defaultVal
+	envVal, ok := os.LookupEnv(name)
+	if ok {
+		intVal, _ := strconv.Atoi(envVal)
+		retVal = uint(intVal)
+	}
+	return retVal
+}
+
+// getEnvOrDefaultBool returns the bool value of the environment variable "name" or "defaultVal" if that variable does not exist.
+func getEnvOrDefaultBool(name string, defaultVal bool) bool {
+	retVal := defaultVal
+	envVal, ok := os.LookupEnv(name)
+	if ok {
+		retVal, _ = strconv.ParseBool(envVal)
+	}
+	return retVal
+}
+
+// retrieveOAuthToken retrieves a usable OAuth token from XMC.
+func retrieveOAuthToken() bool {
+	tokenURL := "https://" + Config.XMCHost + ":" + fmt.Sprint(Config.XMCPort) + "/oauth/token/access-token?grant_type=client_credentials"
+
+	req, reqErr := http.NewRequest(http.MethodPost, tokenURL, nil)
+	if reqErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: Could not create HTTPS request: %s\n", reqErr)
+		return false
+	}
+	req.Header.Set("User-Agent", httpUserAgent)
+	req.Header.Set("Accept", jsonMimeType)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(Config.XMCClientID, Config.XMCClientSecret)
+
+	res, resErr := NBIClient.Do(req)
+	if resErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: Could not connect to XMC: %s\n", resErr)
+		return false
+	}
+	if res.StatusCode != 200 {
+		fmt.Fprintf(os.Stderr, "Error: Got status code %d instead of 200\n", res.StatusCode)
+		return false
+	}
+	defer res.Body.Close()
+
+	resContentType := res.Header.Get("Content-Type")
+	if strings.Index(resContentType, jsonMimeType) != 0 {
+		fmt.Fprintf(os.Stderr, "Error: Content-Type %s returned instead of %s\n", resContentType, jsonMimeType)
+		return false
+	}
+
+	xmcToken, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: Could not read server response: %s\n", readErr)
+		return false
+	}
+
+	jsonErr := json.Unmarshal(xmcToken, &OAuth)
+	if jsonErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: Could not read server response: %s\n", jsonErr)
+		return false
+	}
+
+	return true
+}
+
 func main() {
-	var xmcHost string
-	var httpPort uint
-	var httpTimeout uint
-	var insecureHTTPS bool
-	var httpUsername string
-	var httpPassword string
+	// Variables used for storing options that are not pushed to Config.
 	var xmcQuery string
 	var printVersion bool
+	var useOAuth bool
 
-	flag.StringVar(&xmcHost, "host", "", "XMC Hostname / IP")
-	flag.UintVar(&httpPort, "port", 8443, "HTTP port where XMC is listening")
-	flag.UintVar(&httpTimeout, "httptimeout", 5, "Timeout for HTTP(S) connections")
-	flag.BoolVar(&insecureHTTPS, "insecurehttps", false, "Do not validate HTTPS certificates")
-	flag.StringVar(&httpUsername, "username", "admin", "Username for HTTP auth")
-	flag.StringVar(&httpPassword, "password", "", "Password for HTTP auth")
-	flag.StringVar(&xmcQuery, "query", "query { network { devices { up ip sysName nickName } } }", "GraphQL query to send to XMC")
+	// Parse all valid CLI options into variables.
+	flag.StringVar(&Config.XMCHost, "host", getEnvOrDefaultString("XMCHOST", ""), "XMC Hostname / IP")
+	flag.UintVar(&Config.XMCPort, "port", getEnvOrDefaultUint("XMCPORT", 8443), "HTTP port where XMC is listening")
+	flag.UintVar(&Config.HTTPTimeout, "httptimeout", getEnvOrDefaultUint("XMCTIMEOUT", 5), "Timeout for HTTP(S) connections")
+	flag.BoolVar(&Config.InsecureHTTPS, "insecurehttps", getEnvOrDefaultBool("XMCINSECURE", false), "Do not validate HTTPS certificates")
+	flag.StringVar(&Config.XMCClientID, "clientid", getEnvOrDefaultString("XMCCLIENTID", ""), "Client ID for OAuth2")
+	flag.StringVar(&Config.XMCClientSecret, "clientsecret", getEnvOrDefaultString("XMCCLIENTSECRET", ""), "Client Secret for OAuth2")
+	flag.StringVar(&Config.XMCUsername, "username", getEnvOrDefaultString("XMCUSERNAME", "admin"), "Username for HTTP auth")
+	flag.StringVar(&Config.XMCPassword, "password", getEnvOrDefaultString("XMCPASSWORD", ""), "Password for HTTP auth")
+	flag.StringVar(&xmcQuery, "query", getEnvOrDefaultString("XMCQUERY", "query { network { devices { up ip sysName nickName } } }"), "GraphQL query to send to XMC")
 	flag.BoolVar(&printVersion, "version", false, "Print version information and exit")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "This tool queries the XMC API and prints the raw reply (JSON) to stdout.\n")
@@ -71,43 +184,77 @@ func main() {
 		fmt.Fprintf(os.Stderr, "\n")
 		fmt.Fprintf(os.Stderr, "Available options:\n")
 		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "OAuth2 will be preferred over username/password.\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "All options that take a value can be set via environment variables:\n")
+		fmt.Fprintf(os.Stderr, "  XMCHOST          -->  -host\n")
+		fmt.Fprintf(os.Stderr, "  XMCPORT          -->  -port\n")
+		fmt.Fprintf(os.Stderr, "  XMCINSECURE      -->  -insecurehttps\n")
+		fmt.Fprintf(os.Stderr, "  XMCTIMEOUT       -->  -httptimeout\n")
+		fmt.Fprintf(os.Stderr, "  XMCCLIENTID      -->  -clientid\n")
+		fmt.Fprintf(os.Stderr, "  XMCCLIENTSECRET  -->  -clientsecret\n")
+		fmt.Fprintf(os.Stderr, "  XMCUSERNAME      -->  -username\n")
+		fmt.Fprintf(os.Stderr, "  XMCPASSWORD      -->  -password\n")
+		fmt.Fprintf(os.Stderr, "  XMCQUERY         -->  -query\n")
 		os.Exit(errUsage)
 	}
 	flag.Parse()
 
+	// Print version information and exit.
 	if printVersion {
 		fmt.Println(httpUserAgent)
 		os.Exit(errSuccess)
 	}
 
-	if xmcHost == "" {
+	// Check that the option "host" has been set.
+	if Config.XMCHost == "" {
 		fmt.Fprintln(os.Stderr, "Variable -host must be defined. Use -h to get help.")
 		os.Exit(errMissArg)
 	}
 
-	var apiURL string = "https://" + xmcHost + ":" + fmt.Sprint(httpPort) + "/nbi/graphql"
+	// Create an HTTP client to talk to XMC.
 	httpTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureHTTPS},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: Config.InsecureHTTPS},
 	}
-	nbiClient := http.Client{
+	NBIClient = http.Client{
 		Transport: httpTransport,
-		Timeout:   time.Second * time.Duration(httpTimeout),
+		Timeout:   time.Second * time.Duration(Config.HTTPTimeout),
 	}
 
-	req, reqErr := http.NewRequest(http.MethodGet, apiURL, nil)
+	// Try to get an OAuth token if we have OAuth authentication data.
+	useOAuth = false
+	if Config.XMCClientID != "" && Config.XMCClientSecret != "" {
+		if retrieveOAuthToken() != true {
+			os.Exit(errHTTPOAuth)
+		}
+		useOAuth = true
+	}
+
+	// Generate an actual HTTP request.
+	apiURL := "https://" + Config.XMCHost + ":" + fmt.Sprint(Config.XMCPort) + "/nbi/graphql"
+	jsonQuery, jsonQueryErr := json.Marshal(map[string]string{"query": xmcQuery})
+	if jsonQueryErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: Could not encode query into JSON: %s", jsonQueryErr)
+		os.Exit(errHTTPRequest)
+	}
+	req, reqErr := http.NewRequest(http.MethodPost, apiURL, bytes.NewBuffer(jsonQuery))
 	if reqErr != nil {
 		fmt.Fprintf(os.Stderr, "Error: Could not create HTTPS request: %s\n", reqErr)
 		os.Exit(errHTTPRequest)
 	}
-
 	req.Header.Set("User-Agent", httpUserAgent)
-	req.SetBasicAuth(httpUsername, httpPassword)
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Content-Type", jsonMimeType)
+	req.Header.Set("Accept", jsonMimeType)
+	if useOAuth {
+		req.Header.Set("Authorization", "Bearer "+OAuth.AccessToken)
+	} else {
+		req.SetBasicAuth(Config.XMCUsername, Config.XMCPassword)
+	}
 
-	httpQuery := req.URL.Query()
-	httpQuery.Add("query", xmcQuery)
-	req.URL.RawQuery = httpQuery.Encode()
-
-	res, getErr := nbiClient.Do(req)
+	// Try to get a result from the API.
+	res, getErr := NBIClient.Do(req)
 	if getErr != nil {
 		fmt.Fprintf(os.Stderr, "Error: Could not connect to XMC: %s\n", getErr)
 		os.Exit(errXMCConnect)
@@ -116,13 +263,23 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: Got status code %d instead of 200\n", res.StatusCode)
 		os.Exit(errXMCConnect)
 	}
+	defer res.Body.Close()
 
+	// Check if the HTTP response has yielded the expected content type.
+	resContentType := res.Header.Get("Content-Type")
+	if strings.Index(resContentType, jsonMimeType) != 0 {
+		fmt.Fprintf(os.Stderr, "Error: Content-Type %s returned instead of %s\n", resContentType, jsonMimeType)
+		os.Exit(errHTTPResponse)
+	}
+
+	// Read and print the body of the HTTP response to stdout.
 	body, readErr := ioutil.ReadAll(res.Body)
 	if readErr != nil {
 		fmt.Fprintf(os.Stderr, "Error: Could not read server response: %s\n", readErr)
-		os.Exit(errHTTPSResponse)
+		os.Exit(errHTTPResponse)
 	}
 	fmt.Println(string(body))
 
+	// Indicate a successful execution of the program.
 	os.Exit(errSuccess)
 }

--- a/Netsight/nbi_clients/GenericNbiClient.go/GenericNbiClient.go
+++ b/Netsight/nbi_clients/GenericNbiClient.go/GenericNbiClient.go
@@ -26,6 +26,7 @@ package main
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -49,18 +50,36 @@ type AppConfig struct {
 	XMCUsername     string
 	XMCPassword     string
 	XMCQuery        string
+	UseOAuth        bool
+	PrintVersion    bool
 }
 
 // OAuth2Token stores the OAuth2 Token used for authentication.
 type OAuth2Token struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
+	TokenType     string `json:"token_type"`
+	AccessToken   string `json:"access_token"`
+	TokenElements OAuth2TokenElements
+}
+
+// OAuth2TokenElements stores decoded information contained in a valid OAuth2 token.
+type OAuth2TokenElements struct {
+	Issuer           string   `json:"iss,omitempty"`
+	Subject          string   `json:"sub,omitempty"`
+	JWTID            string   `json:"jti,omitempty"`
+	Roles            []string `json:"roles,omitempty"`
+	IsuedAtUnixfmt   int64    `json:"iat,omitempty"`
+	NotBeforeUnixfmt int64    `json:"nbf,omitempty"`
+	ExpiresAtUnixfmt int64    `json:"exp,omitempty"`
+	IssuedAt         time.Time
+	NotBefore        time.Time
+	ExpiresAt        time.Time
+	LongLived        bool `json:"longLived,omitempty"`
 }
 
 // Definitions used within the code.
 const (
 	toolName      string = "XMC NBI GenericNbiClient.go"
-	toolVersion   string = "0.6.0"
+	toolVersion   string = "0.6.6"
 	httpUserAgent string = toolName + "/" + toolVersion
 	jsonMimeType  string = "application/json"
 )
@@ -115,58 +134,123 @@ func getEnvOrDefaultBool(name string, defaultVal bool) bool {
 }
 
 // retrieveOAuthToken retrieves a usable OAuth token from XMC.
-func retrieveOAuthToken() bool {
+func retrieveOAuthToken() (string, int, error) {
 	tokenURL := "https://" + Config.XMCHost + ":" + fmt.Sprint(Config.XMCPort) + "/oauth/token/access-token?grant_type=client_credentials"
 
+	// Generate an actual HTTP request.
 	req, reqErr := http.NewRequest(http.MethodPost, tokenURL, nil)
 	if reqErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not create HTTPS request: %s\n", reqErr)
-		return false
+		return "", errHTTPRequest, fmt.Errorf("Could not create HTTPS request: %s", reqErr)
 	}
 	req.Header.Set("User-Agent", httpUserAgent)
+	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Accept", jsonMimeType)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(Config.XMCClientID, Config.XMCClientSecret)
 
+	// Try to get a result from the API.
 	res, resErr := NBIClient.Do(req)
 	if resErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not connect to XMC: %s\n", resErr)
-		return false
+		return "", errXMCConnect, fmt.Errorf("Could not connect to XMC: %s", resErr)
 	}
 	if res.StatusCode != 200 {
-		fmt.Fprintf(os.Stderr, "Error: Got status code %d instead of 200\n", res.StatusCode)
-		return false
+		return "", errXMCConnect, fmt.Errorf("Got status code %d instead of 200", res.StatusCode)
 	}
 	defer res.Body.Close()
 
+	// Check if the HTTP response has yielded the expected content type.
 	resContentType := res.Header.Get("Content-Type")
 	if strings.Index(resContentType, jsonMimeType) != 0 {
-		fmt.Fprintf(os.Stderr, "Error: Content-Type %s returned instead of %s\n", resContentType, jsonMimeType)
-		return false
+		return "", errHTTPResponse, fmt.Errorf("Content-Type %s returned instead of %s", resContentType, jsonMimeType)
 	}
 
+	// Read and parse the body of the HTTP response.
 	xmcToken, readErr := ioutil.ReadAll(res.Body)
 	if readErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not read server response: %s\n", readErr)
-		return false
+		return "", errHTTPResponse, fmt.Errorf("Could not read server response: %s", readErr)
 	}
-
 	jsonErr := json.Unmarshal(xmcToken, &OAuth)
 	if jsonErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not read server response: %s\n", jsonErr)
-		return false
+		return "", errHTTPResponse, fmt.Errorf("Could not read server response: %s", jsonErr)
 	}
 
-	return true
+	return OAuth.AccessToken, errSuccess, nil
 }
 
-func main() {
-	// Variables used for storing options that are not pushed to Config.
-	var xmcQuery string
-	var printVersion bool
-	var useOAuth bool
+// decodeOAuthToken decodes certain parts of the OAuth token.
+func decodeOAuthToken() (OAuth2TokenElements, error) {
+	var tokenElements OAuth2TokenElements
 
-	// Parse all valid CLI options into variables.
+	// Seperate and base64 decode the relevant part of the token.
+	tokenParts := strings.Split(OAuth.AccessToken, ".")
+	tokenData, tokenErr := base64.StdEncoding.DecodeString(fmt.Sprintf("%s==", tokenParts[1]))
+	if tokenErr != nil {
+		return tokenElements, tokenErr
+	}
+
+	// Parse the JSON into our struct.
+	decodeErr := json.Unmarshal(tokenData, &tokenElements)
+	if decodeErr != nil {
+		return tokenElements, decodeErr
+	}
+
+	// Transform UNIX timestamps into time.Time objects.
+	tokenElements.IssuedAt = time.Unix(tokenElements.IsuedAtUnixfmt, 0)
+	tokenElements.NotBefore = time.Unix(tokenElements.NotBeforeUnixfmt, 0)
+	tokenElements.ExpiresAt = time.Unix(tokenElements.ExpiresAtUnixfmt, 0)
+
+	return tokenElements, nil
+}
+
+// retrieveAPIResult sends the given query to XMC and returns the raw JSON result, an error code for os.Exit() and the actual error.
+func retrieveAPIResult(query string) (string, int, error) {
+	apiURL := "https://" + Config.XMCHost + ":" + fmt.Sprint(Config.XMCPort) + "/nbi/graphql"
+
+	// Generate an actual HTTP request.
+	jsonQuery, jsonQueryErr := json.Marshal(map[string]string{"query": query})
+	if jsonQueryErr != nil {
+		return "", errHTTPRequest, fmt.Errorf("Could not encode query into JSON: %s", jsonQueryErr)
+	}
+	req, reqErr := http.NewRequest(http.MethodPost, apiURL, bytes.NewBuffer(jsonQuery))
+	if reqErr != nil {
+		return "", errHTTPRequest, fmt.Errorf("Could not create HTTPS request: %s", reqErr)
+	}
+	req.Header.Set("User-Agent", httpUserAgent)
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Content-Type", jsonMimeType)
+	req.Header.Set("Accept", jsonMimeType)
+	if Config.UseOAuth {
+		req.Header.Set("Authorization", "Bearer "+OAuth.AccessToken)
+	} else {
+		req.SetBasicAuth(Config.XMCUsername, Config.XMCPassword)
+	}
+
+	// Try to get a result from the API.
+	res, resErr := NBIClient.Do(req)
+	if resErr != nil {
+		return "", errXMCConnect, fmt.Errorf("Could not connect to XMC: %s", resErr)
+	}
+	if res.StatusCode != 200 {
+		return "", errXMCConnect, fmt.Errorf("Got status code %d instead of 200", res.StatusCode)
+	}
+	defer res.Body.Close()
+
+	// Check if the HTTP response has yielded the expected content type.
+	resContentType := res.Header.Get("Content-Type")
+	if strings.Index(resContentType, jsonMimeType) != 0 {
+		return "", errHTTPResponse, fmt.Errorf("Content-Type %s returned instead of %s", resContentType, jsonMimeType)
+	}
+
+	// Read the body of the HTTP response.
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		return "", errHTTPResponse, fmt.Errorf("Could not read server response: %s", readErr)
+	}
+
+	return string(body), errSuccess, nil
+}
+
+func parseCLIOptions() {
 	flag.StringVar(&Config.XMCHost, "host", getEnvOrDefaultString("XMCHOST", ""), "XMC Hostname / IP")
 	flag.UintVar(&Config.XMCPort, "port", getEnvOrDefaultUint("XMCPORT", 8443), "HTTP port where XMC is listening")
 	flag.UintVar(&Config.HTTPTimeout, "httptimeout", getEnvOrDefaultUint("XMCTIMEOUT", 5), "Timeout for HTTP(S) connections")
@@ -175,8 +259,8 @@ func main() {
 	flag.StringVar(&Config.XMCClientSecret, "clientsecret", getEnvOrDefaultString("XMCCLIENTSECRET", ""), "Client Secret for OAuth2")
 	flag.StringVar(&Config.XMCUsername, "username", getEnvOrDefaultString("XMCUSERNAME", "admin"), "Username for HTTP auth")
 	flag.StringVar(&Config.XMCPassword, "password", getEnvOrDefaultString("XMCPASSWORD", ""), "Password for HTTP auth")
-	flag.StringVar(&xmcQuery, "query", getEnvOrDefaultString("XMCQUERY", "query { network { devices { up ip sysName nickName } } }"), "GraphQL query to send to XMC")
-	flag.BoolVar(&printVersion, "version", false, "Print version information and exit")
+	flag.StringVar(&Config.XMCQuery, "query", getEnvOrDefaultString("XMCQUERY", "query { network { devices { up ip sysName nickName } } }"), "GraphQL query to send to XMC")
+	flag.BoolVar(&Config.PrintVersion, "version", false, "Print version information and exit")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "This tool queries the XMC API and prints the raw reply (JSON) to stdout.\n")
 		fmt.Fprintf(os.Stderr, "\n")
@@ -200,9 +284,14 @@ func main() {
 		os.Exit(errUsage)
 	}
 	flag.Parse()
+}
+
+func main() {
+	// Parse all valid CLI options into variables.
+	parseCLIOptions()
 
 	// Print version information and exit.
-	if printVersion {
+	if Config.PrintVersion {
 		fmt.Println(httpUserAgent)
 		os.Exit(errSuccess)
 	}
@@ -223,63 +312,30 @@ func main() {
 	}
 
 	// Try to get an OAuth token if we have OAuth authentication data.
-	useOAuth = false
+	Config.UseOAuth = false
 	if Config.XMCClientID != "" && Config.XMCClientSecret != "" {
-		if retrieveOAuthToken() != true {
+		_, _, oAuthErr := retrieveOAuthToken()
+		if oAuthErr != nil {
+			fmt.Fprintf(os.Stderr, "Could not retrieve OAuth token: %s\n", oAuthErr)
 			os.Exit(errHTTPOAuth)
 		}
-		useOAuth = true
+		tokenElements, decodeErr := decodeOAuthToken()
+		if decodeErr != nil {
+			fmt.Fprintf(os.Stderr, "Could not decode OAuth token: %s\n", decodeErr)
+			os.Exit(errHTTPOAuth)
+		}
+		OAuth.TokenElements = tokenElements
+		Config.UseOAuth = true
 	}
 
-	// Generate an actual HTTP request.
-	apiURL := "https://" + Config.XMCHost + ":" + fmt.Sprint(Config.XMCPort) + "/nbi/graphql"
-	jsonQuery, jsonQueryErr := json.Marshal(map[string]string{"query": xmcQuery})
-	if jsonQueryErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not encode query into JSON: %s", jsonQueryErr)
-		os.Exit(errHTTPRequest)
-	}
-	req, reqErr := http.NewRequest(http.MethodPost, apiURL, bytes.NewBuffer(jsonQuery))
-	if reqErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not create HTTPS request: %s\n", reqErr)
-		os.Exit(errHTTPRequest)
-	}
-	req.Header.Set("User-Agent", httpUserAgent)
-	req.Header.Set("Cache-Control", "no-cache")
-	req.Header.Set("Content-Type", jsonMimeType)
-	req.Header.Set("Accept", jsonMimeType)
-	if useOAuth {
-		req.Header.Set("Authorization", "Bearer "+OAuth.AccessToken)
+	// Call the API and print the result.
+	apiResult, exitCode, apiError := retrieveAPIResult(Config.XMCQuery)
+	if apiError != nil {
+		fmt.Fprintf(os.Stderr, "Could not retrieve API result: %s\n", apiError)
 	} else {
-		req.SetBasicAuth(Config.XMCUsername, Config.XMCPassword)
+		fmt.Println(string(apiResult))
 	}
 
-	// Try to get a result from the API.
-	res, getErr := NBIClient.Do(req)
-	if getErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not connect to XMC: %s\n", getErr)
-		os.Exit(errXMCConnect)
-	}
-	if res.StatusCode != 200 {
-		fmt.Fprintf(os.Stderr, "Error: Got status code %d instead of 200\n", res.StatusCode)
-		os.Exit(errXMCConnect)
-	}
-	defer res.Body.Close()
-
-	// Check if the HTTP response has yielded the expected content type.
-	resContentType := res.Header.Get("Content-Type")
-	if strings.Index(resContentType, jsonMimeType) != 0 {
-		fmt.Fprintf(os.Stderr, "Error: Content-Type %s returned instead of %s\n", resContentType, jsonMimeType)
-		os.Exit(errHTTPResponse)
-	}
-
-	// Read and print the body of the HTTP response to stdout.
-	body, readErr := ioutil.ReadAll(res.Body)
-	if readErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not read server response: %s\n", readErr)
-		os.Exit(errHTTPResponse)
-	}
-	fmt.Println(string(body))
-
-	// Indicate a successful execution of the program.
-	os.Exit(errSuccess)
+	// Exit with an appropriate exit code.
+	os.Exit(exitCode)
 }

--- a/Netsight/nbi_clients/GenericNbiClient.go/README.md
+++ b/Netsight/nbi_clients/GenericNbiClient.go/README.md
@@ -1,4 +1,4 @@
-# XMC NBI GenericNbiClient (Go)
+# GenericNbiClient.go
 
 [GenericNbiClient.go](https://github.com/extremenetworks/ExtremeScripting/blob/master/Netsight/nbi_clients/GenericNbiClient.go/GenericNbiClient.go) sends a query to the GraphQL-based API provided by the Northbound Interface (NBI) of Extreme Management Center and prints the raw JSON response to stdout.
 

--- a/Netsight/nbi_clients/GenericNbiClient.go/README.md
+++ b/Netsight/nbi_clients/GenericNbiClient.go/README.md
@@ -1,4 +1,4 @@
-# GenericNbiClient.go
+# XMC NBI GenericNbiClient (Go)
 
 [GenericNbiClient.go](https://github.com/extremenetworks/ExtremeScripting/blob/master/Netsight/nbi_clients/GenericNbiClient.go/GenericNbiClient.go) sends a query to the GraphQL-based API provided by the Northbound Interface (NBI) of Extreme Management Center and prints the raw JSON response to stdout.
 
@@ -6,13 +6,18 @@
 
 Use `go run GenericNbiClient.go` to run the tool directly or `go build GenericNbiClient.go` to compile a binary.
 
-Tested with go1.11 and go1.13.
+Tested with go1.13.
 
 ## Usage
 
 `GenericNbiClient -h`:
 
 <pre>
+Available options:
+  -clientid string
+        Client ID for OAuth2
+  -clientsecret string
+        Client Secret for OAuth2
   -host string
         XMC Hostname / IP
   -httptimeout uint
@@ -29,6 +34,19 @@ Tested with go1.11 and go1.13.
         Username for HTTP auth (default "admin")
   -version
         Print version information and exit
+
+OAuth2 will be preferred over username/password.
+
+All options that take a value can be set via environment variables:
+  XMCHOST          -->  -host
+  XMCPORT          -->  -port
+  XMCINSECURE      -->  -insecurehttps
+  XMCTIMEOUT       -->  -httptimeout
+  XMCCLIENTID      -->  -clientid
+  XMCCLIENTSECRET  -->  -clientsecret
+  XMCUSERNAME      -->  -username
+  XMCPASSWORD      -->  -password
+  XMCQUERY         -->  -query
 </pre>
 
 ## Source
@@ -38,3 +56,4 @@ The original project is [hosted at GitLab](https://gitlab.com/rbrt-weiler/xmc-nb
 ## Support
 
 _The software is provided as-is and neither [Extreme Networks](http://www.extremenetworks.com/) nor [BELL Computer-Netzwerke GmbH](https://www.bell.de/) has no obligation to provide maintenance, support, updates, enhancements, or modifications. Any support provided by [Extreme Networks](http://www.extremenetworks.com/) or [BELL Computer-Netzwerke GmbH](https://www.bell.de/) is at its sole discretion._
+


### PR DESCRIPTION
The new version offers OAuth2 (besides HTTP Basic Auth) and uses POST instead of GET to send queries to the NBI. Thanks to Extreme's Markus for the input!