### PR TITLE
Bump GenericNbiClient.go to v0.11.1.

### DIFF
--- a/Netsight/nbi_clients/GenericNbiClient.go/README.md
+++ b/Netsight/nbi_clients/GenericNbiClient.go/README.md
@@ -4,7 +4,13 @@
 
 ## Dependencies
 
-GenericNbiClient uses the [module xmcnbiclient](https://gitlab.com/rbrt-weiler/go-module-xmcnbiclient). This module has to be installed with `go get gitlab.com/rbrt-weiler/go-module-xmcnbiclient` or updated with `go get -u gitlab.com/rbrt-weiler/go-module-xmcnbiclient` before running or compiling GenericNbiClient. All other dependencies are included in a standard Go installation.
+GenericNbiClient uses the modules [godotenv](https://github.com/joho/godotenv), [envordef](https://gitlab.com/rbrt-weiler/go-module-envordef) and [xmcnbiclient](https://gitlab.com/rbrt-weiler/go-module-xmcnbiclient). Execute...
+
+1. `go get -u github.com/joho/godotenv`
+1. `go get -u gitlab.com/rbrt-weiler/go-module-envordef`
+1. `go get -u gitlab.com/rbrt-weiler/go-module-xmcnbiclient`
+
+...before running or compiling GenericNbiClient. All other dependencies are included in a standard Go installation.
 
 ## Compiling
 
@@ -19,27 +25,27 @@ Tested with [go1.13](https://golang.org/doc/go1.13).
 <pre>
 Available options:
   -basicauth
-        Use HTTP Basic Auth instead of OAuth
+    	Use HTTP Basic Auth instead of OAuth
   -host string
-        XMC Hostname / IP
+    	XMC Hostname / IP
   -insecurehttps
-        Do not validate HTTPS certificates
+    	Do not validate HTTPS certificates
   -nohttps
-        Use HTTP instead of HTTPS
+    	Use HTTP instead of HTTPS
   -path string
-        Path where XMC is reachable
+    	Path where XMC is reachable
   -port uint
-        HTTP port where XMC is listening (default 8443)
+    	HTTP port where XMC is listening (default 8443)
   -query string
-        GraphQL query to send to XMC (default "query { network { devices { up ip sysName nickName } } }")
+    	GraphQL query to send to XMC (default "query { network { devices { up ip sysName nickName } } }")
   -secret string
-        Client Secret (OAuth) or password (Basic Auth) for authentication
+    	Client Secret (OAuth) or password (Basic Auth) for authentication
   -timeout uint
-        Timeout for HTTP(S) connections (default 5)
+    	Timeout for HTTP(S) connections (default 5)
   -userid string
-        Client ID (OAuth) or username (Basic Auth) for authentication
+    	Client ID (OAuth) or username (Basic Auth) for authentication
   -version
-        Print version information and exit
+    	Print version information and exit
 
 All options that take a value can be set via environment variables:
   XMCHOST       -->  -host
@@ -52,6 +58,10 @@ All options that take a value can be set via environment variables:
   XMCSECRET     -->  -secret
   XMCBASICAUTH  -->  -basicauth
   XMCQUERY      -->  -query
+
+Environment variables can also be configured via a file called .xmcenv,
+located in the current directory or in the home directory of the current
+user.
 </pre>
 
 ## Authentication
@@ -69,7 +79,7 @@ In order to use OAuth2 you will need to create a Client API Access client. To cr
 
 Any user or API client who wants to access the Northbound Interface needs the appropriate access rights. In general, checking the full _Northbound API_ section within rights management will suffice. Depending on the use case, it may be feasible to go into detail and restrict the rights to the bare minimum required.
 
-For regular users (HTTP Basic Auth) the rights are managed via _Authorization Groups_ found in the _Administration_ -> _Users_ tab within XMC. For API clients (OAuth2) the rights are defined when creating an API client and can later be adjusted in the same tab.
+For API clients (OAuth2) the rights are defined when creating an API client and can later be adjusted in the same tab. For regular users (HTTP Basic Auth) the rights are managed via _Authorization Groups_ found in the _Administration_ -> _Users_ tab within XMC.
 
 ## Source
 


### PR DESCRIPTION
With the newest version, it is possible to use a file called .xmcenv to configure all necessary arguments.