### PR TITLE
Added deprecation notice for GenericNbiClient.py.

### DIFF
--- a/Netsight/nbi_clients/GenericNbiClient.py/README.md
+++ b/Netsight/nbi_clients/GenericNbiClient.py/README.md
@@ -2,6 +2,8 @@
 
 [GenericNbiClient.py](GenericNbiClient.py?raw=true) sends a query to the GraphQL-based API provided by the Northbound Interface (NBI) of Extreme Management Center and prints the raw JSON response to stdout.
 
+**Notice**: This project has surfaced as a proof of concept and is _not maintained_ anymore. If you need a production ready NBI client, please refer to [the Go version of GenericNbiClient](../GenericNbiClient.go/README.md).
+
 ## Dependencies
 
 GenericNbiClient.py requires the Python module `requests` to be installed. PIP may be used to install it:

--- a/Netsight/nbi_clients/README.md
+++ b/Netsight/nbi_clients/README.md
@@ -3,7 +3,7 @@
 Client applications that utilize the NBI API provided by Extreme Management Center (Netsight).
 
 * [GenericNbiClient.go](GenericNbiClient.go/README.md): Application written in Go that can be used to send generic GraphQL queries to a remote XMC instance.
-* [GenericNbiClient.py](GenericNbiClient.py/README.md): Application written in Python that can be used to send generic GraphQL queries to a remote XMC instance.
+* [GenericNbiClient.py](GenericNbiClient.py/README.md) (deprecated): Application written in Python that can be used to send generic GraphQL queries to a remote XMC instance.
 
 ## Support
 


### PR DESCRIPTION
GenericNbiClient.py is outdated and not maintained anymore. Added notice to use the Go version instead.