### PR TITLE
Fix decoding of JWT

### DIFF
--- a/Netsight/nbi_clients/Python3/XMC_NBI.py
+++ b/Netsight/nbi_clients/Python3/XMC_NBI.py
@@ -134,7 +134,7 @@ class XMC_NBI():
             self.token  = result[u'access_token']
 
             xmcTokenElements = self.token.split('.')
-            tokenData = json.loads( base64.b64decode(xmcTokenElements[1]+ "==") )
+            tokenData = json.loads( base64.urlsafe_b64decode(xmcTokenElements[1]+ "==") )
             self.expire = self._computeExpireTime( datetime.fromtimestamp( tokenData['iat'] ), datetime.fromtimestamp( tokenData['exp'] ) )
 
             logger.debug('            Issuer: %s' % tokenData['iss'] )

--- a/Netsight/nbi_clients/Python3/requirements.txt
+++ b/Netsight/nbi_clients/Python3/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2021.5.30
+chardet==4.0.0
+idna==2.10
+requests==2.25.1
+urllib3==1.26.5


### PR DESCRIPTION
JSON Web Tokens do not use standard base64, but base64url for encoding data. See https://jwt.io/introduction for details. This has been fixed in the Python class with this PR.

In addition, this PR includes a requirements.txt to automate dependency installation using `python -m pip install -r requirements.txt`.