### PR TITLE
Fix JWT string conversion

### DIFF
--- a/Netsight/nbi_clients/Python3/XMC_NBI.py
+++ b/Netsight/nbi_clients/Python3/XMC_NBI.py
@@ -134,7 +134,8 @@ class XMC_NBI():
             self.token  = result[u'access_token']
 
             xmcTokenElements = self.token.split('.')
-            tokenData = json.loads( base64.urlsafe_b64decode(xmcTokenElements[1]+ "==") )
+            xmcTokenDataJSON = str(base64.urlsafe_b64decode(xmcTokenElements[1] + "=="), 'utf8')
+            tokenData = json.loads(xmcTokenDataJSON)
             self.expire = self._computeExpireTime( datetime.fromtimestamp( tokenData['iat'] ), datetime.fromtimestamp( tokenData['exp'] ) )
 
             logger.debug('            Issuer: %s' % tokenData['iss'] )


### PR DESCRIPTION
str() in Python3 requires a charset to properly convert bytes into a string. This has been fixed with this PR. Tested with Python 3.5 and 3.9.